### PR TITLE
Add NoTrack path for trackid

### DIFF
--- a/src/mprisServer.c
+++ b/src/mprisServer.c
@@ -121,7 +121,7 @@ GVariant* getMetadataForTrack(int track_id, struct MprisData *mprisData) {
 
 		deadbeef->pl_lock();
 
-		sprintf(buf, "/DeaDBeeF/%d/%d", playlistIndex, id);
+		sprintf(buf, "/org/mpris/MediaPlayer2/TrackList/NoTrack");
 		debug("get Metadata trackid: %s", buf);
 		g_variant_builder_add(builder, "{sv}", "mpris:trackid", g_variant_new("o", buf));
 

--- a/src/mprisServer.c
+++ b/src/mprisServer.c
@@ -392,7 +392,7 @@ static void onPlayerMethodCallHandler(GDBusConnection *connection, const char *s
 			int playid = deadbeef->plt_get_item_idx(pl, track, PL_MAIN);
 			int playlistIndex = deadbeef->plt_get_curr_idx();
 			char buf[200];
-			sprintf(buf, "/DeaDBeeF/%d/%d", playlistIndex, playid);
+			sprintf(buf, "/org/mpris/MediaPlayer2/TrackList/NoTrack");
 			if (strcmp(buf, trackId) == 0) {
 				deadbeef->sendmessage(DB_EV_SEEK, 0, position / 1000.0, 0);
 			}


### PR DESCRIPTION
Since this mpris plugin doesn't support a TrackList we better do the right thing.
This squashes errors like: GLib-CRITICAL **: g_variant_new_object_path: assertion 'g_variant_is_object_path (object_path)' failed