### PR TITLE
Fix emitSeeked in SetPosition

### DIFF
--- a/src/mprisServer.c
+++ b/src/mprisServer.c
@@ -398,7 +398,7 @@ static void onPlayerMethodCallHandler(GDBusConnection *connection, const char *s
 			}
 			deadbeef->pl_item_unref(track);
 			deadbeef->plt_unref(pl);
-			emitSeeked(deadbeef->streamer_get_playpos() * 1000.0);
+			emitSeeked(deadbeef->streamer_get_playpos());
 		}
 		g_dbus_method_invocation_return_value(invocation, NULL);
 	} else if (strcmp(methodName, "OpenUri") == 0) {


### PR DESCRIPTION
gets rid of erratic seekbar behavior in clients.

* Also not sure you need to emitSeeked here at all. Seems to work fine even if you don't.
