### PR TITLE
Emit CanSeek changes as well during playback status changes

### DIFF
--- a/src/mpris.c
+++ b/src/mpris.c
@@ -71,20 +71,20 @@ static int handleEvent (uint32_t id, uintptr_t ctx, uint32_t p1, uint32_t p2) {
 		case DB_EV_SONGSTARTED:
 			debug("DB_EV_SONGSTARTED event received");
 			emitMetadataChanged(-1, &mprisData);
-			emitPlaybackStatusChanged(lastState = OUTPUT_STATE_PLAYING);
+			emitPlaybackStatusChanged(lastState = OUTPUT_STATE_PLAYING, &mprisData);
 			break;
 		case DB_EV_PAUSED:
 			debug("DB_EV_PAUSED event received");
 			debug("PlayPause toggled... last state %d", lastState);
 			switch (lastState) {
 				case -1:
-					emitPlaybackStatusChanged(lastState = deadbeef->get_output()->state());
+					emitPlaybackStatusChanged(lastState = deadbeef->get_output()->state(), &mprisData);
 					break;
 				case OUTPUT_STATE_PLAYING:
-					emitPlaybackStatusChanged(lastState = OUTPUT_STATE_PAUSED);
+					emitPlaybackStatusChanged(lastState = OUTPUT_STATE_PAUSED, &mprisData);
 					break;
 				case OUTPUT_STATE_PAUSED:
-					emitPlaybackStatusChanged(lastState = OUTPUT_STATE_PLAYING);
+					emitPlaybackStatusChanged(lastState = OUTPUT_STATE_PLAYING, &mprisData);
 					break;
 				default:
 					break;
@@ -92,7 +92,7 @@ static int handleEvent (uint32_t id, uintptr_t ctx, uint32_t p1, uint32_t p2) {
 			break;
 		case DB_EV_STOP:
 			debug("DB_EV_STOP event received");
-			emitPlaybackStatusChanged(OUTPUT_STATE_STOPPED);
+			emitPlaybackStatusChanged(OUTPUT_STATE_STOPPED, &mprisData);
 			break;
 		case DB_EV_VOLUMECHANGED:
 			debug("DB_EV_VOLUMECHANGED event received");

--- a/src/mprisServer.h
+++ b/src/mprisServer.h
@@ -20,7 +20,7 @@ void stopServer(void);
 void emitVolumeChanged(float);
 void emitSeeked(float);
 void emitMetadataChanged(int, struct MprisData*);
-void emitPlaybackStatusChanged(int);
+void emitPlaybackStatusChanged(int, struct MprisData *);
 void emitLoopStatusChanged(int);
 void emitShuffleStatusChanged(int);
 


### PR DESCRIPTION
This is because if property getter for CanSeek is called too early it returns incorrect values (deadbeef doesn't know the duration at that point).
Updating this property on playback status changes solves the issue.
