### PR TITLE
Fix segfault at startup (fixes issue #10)

### DIFF
--- a/src/mprisServer.c
+++ b/src/mprisServer.c
@@ -467,6 +467,8 @@ static GVariant* onPlayerGetPropertyHandler(GDBusConnection *connection, const c
 				result = g_variant_new_string("Stopped");
 				break;
 			}
+		} else {
+			result = g_variant_new_string("Stopped");
 		}
 	} else if (strcmp(propertyName, "LoopStatus") == 0) {
 		int loop = deadbeef->conf_get_int("playback.loop", PLAYBACK_MODE_LOOP_ALL);


### PR DESCRIPTION
Resolves issues #10 and #11.

The crash occurs when a client queries `PlaybackStatus` before deadbeef is done loading. `deadbeef->get_output()` returns NULL, which is not handled.

I was able to reproduce the crash more frequently (about 9 times out of 10) by emptying the cache right before running deadbeef:
`sync; sudo tee /proc/sys/vm/drop_caches <<<1; deadbeef`