### PR TITLE
Use title formatting v2 ddb APIs to produce MPRIS metadata

### DIFF
--- a/src/mprisServer.h
+++ b/src/mprisServer.h
@@ -4,7 +4,7 @@
 #include <gio/gio.h>
 #include <gio/gdesktopappinfo.h>
 
-#define DDB_API_LEVEL 7
+#define DDB_API_LEVEL 9
 #define DDB_WARN_DEPRECATED 1
 #include <deadbeef/deadbeef.h>
 #include "artwork.h"


### PR DESCRIPTION
When file without tags is played, MPRIS control does not show track title and artist name:
![screen ng](https://user-images.githubusercontent.com/774509/59688666-8a194a00-9221-11e9-8d82-38bd1f0e0d36.png)

This is discouraging because deadbeef itself show file name as track title and "Unknown Artist" as artist name in its own playlist in this case.

This change aligns plugin behavior with player's one:
![screen good](https://user-images.githubusercontent.com/774509/59689063-4e32b480-9222-11e9-81c0-2a3ebb9b856f.png)

The most correct way to fix this seemed to use title formatting APIs with %title% placeholder to produce track title and $if(%artist%,%artist%,Unknown Artist) condition to produce artist name. In this case, player will handle missing title/artist properly by itself, because this is how it formats corresponding fields internally.

This change brings unified approach to fill all metadata fields that could be produced using titleformatting, including mentioned "title" and "artist"  .

This change also fixes two other minor bugs:
- Previously, file:// scheme was appended to ":URI" metadata record unconditionally, which produced incorrect "xesam:url" field for network sources: "file://http://trace.dnbradio.com:8000/dnbradio_main.mp3". Now file:// scheme is appended only to file paths
- Previously, "lyrics" metadata record was used to access track lyrics. This is not working because deadbeef actually stores lyrics inside "unsynced lyrics" metadata record. This is also fixed.